### PR TITLE
Remove default Jekyll meta description text

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: PDX Hackerspace
 email: jon@ctrlh.org
 url: http://pdxhackerspace.org
-description: "Portland's Hackerspace. You can edit this line in _config.yml. It will appear in your document head meta (for Google search results) and in your feed.xml site description."
+description: "Calling all PDX Hackers and Makers! This is your space."
 
 # Color settings (hex-codes without the leading hash-tag)
 color:


### PR DESCRIPTION
Jekyll adds a reference to `_config.yml` to the site's meta description text by default, which sucks. This commit replaces the default text with the description found on http://www.meetup.com/CTRL-H/.
