### PR TITLE
Fix site description meta tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: PDX Hackerspace
 email: jon@ctrlh.org
 url: http://pdxhackerspace.org
-description: "Portland's Hackerspace. You can edit this line in _config.yml. It will appear in your document head meta (for Google search results) and in your feed.xml site description."
+description: "Portland's Hackerspace."
 
 # Color settings (hex-codes without the leading hash-tag)
 color:


### PR DESCRIPTION
This fixes the description in search engines and tools like slack.
