### PR TITLE
Remove boilerplate from description meta tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: PDX Hackerspace
 email: jon@ctrlh.org
 url: http://pdxhackerspace.org
-description: "Portland's Hackerspace. You can edit this line in _config.yml. It will appear in your document head meta (for Google search results) and in your feed.xml site description."
+description: "Portland's Hackerspace. North Portland's place for tinkering, making, and hacking."
 
 # Color settings (hex-codes without the leading hash-tag)
 color:


### PR DESCRIPTION
I noticed that when linking to the website from Slack, the link preview showed
boilerplate text; this commit changes it to text customized for ctrlh.

![screenshot 2017-01-05 12 31 11](https://cloud.githubusercontent.com/assets/56753/21696473/1b7ea5bc-d343-11e6-97bf-f875cde1a1a2.png)
